### PR TITLE
parse empty strings within quotes

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -5,8 +5,8 @@ var ini = require('../lib/multilevel-ini.js');
  */
 function assert(patern, value, line) {
     if (patern !== value) {
-        console.log('[Fail] Excepted in ' + (''+line) + ': (' + 
-            (''+typeof(patern)) + ')"' + (''+patern) + '"' + 
+        console.log('[Fail] Excepted in ' + (''+line) + ': (' +
+            (''+typeof(patern)) + ')"' + (''+patern) + '"' +
             ' given (' + (''+typeof(value)) + ')"' + (''+value) + '"\n');
         return false;
     } else {
@@ -30,7 +30,9 @@ ini.get('test.ini', function(error, ini) {
             assert('other text', ini['First']['foo']['foo'][3], '[First] foo.foo.3');
             assert('text" and other ; text', ini['First']['bar'], '[First] bar');
             assert('text\\\\" and other ; text', ini['First']['far'], '[First] far');
-            
+            assert('', ini['First']['empty'], '[First] empty');
+            assert('', ini['First']['nothing'], '[First] nothing');
+
             assert('1', ini['Second']['foo']['bar'], '[Second] foo.bar');
             assert('', ini['Second']['foo']['bar2'], '[Second] foo.bar2');
             assert('any text', ini['Second']['foo']['bar3'], '[Second] foo.bar3');
@@ -52,7 +54,8 @@ var exObj = {
                   'foo': [1,2,3,4,5,7,8,9]
               }
           },
-          'bar': 'Foo \' other ; \\\\\"'
+          'bar': 'Foo \' other ; \\\\\"',
+          'empty': ''
       },
       'Second : First': {
           'foo': {

--- a/examples/test.ini
+++ b/examples/test.ini
@@ -9,6 +9,8 @@ foo.foo[] = 2.3123
 foo.foo[] = "other text"
 bar = "text\" and other ; text"
 far = "text\\\\\" and other ; text"
+empty = ""
+nothing =
 
 [Second:First]
 foo.foo.3 = "new text"

--- a/lib/multilevel-ini.js
+++ b/lib/multilevel-ini.js
@@ -11,7 +11,7 @@ var PATT_SLASH = /(\\+)$/;
 // utility
 /**
  * Very lazy solution to copy object :)
- * 
+ *
  * @param object obj
  *
  * @return object
@@ -24,7 +24,7 @@ function clone(obj) {
  * Strip slashes
  *
  * @param string strData
- * 
+ *
  * @return string
  */
 function stripslashes(strData) {
@@ -37,9 +37,9 @@ function stripslashes(strData) {
 
 /**
  * Add slashes
- * 
+ *
  * @param string strData
- * 
+ *
  * @return string
  */
 function addslashes(strData) {
@@ -125,13 +125,13 @@ function iniToObj(str) {
     for (var i=0; i < lines.length; i++) {
         var line = lines[i].replace(/(\r$|^\s*|\s*$)/gi, '');
         var localResultPoint = resultPoint;
-        
+
         // coment line like ; some coment
         if (line == '' || isComent(line)) {
             continue;
         }
         var matches = [];
-        
+
         // title line like [Title] or [Title:Parent]
         if (matches = isTitle(line)) {
             if (typeof(matches[3]) == typeof('')) {
@@ -142,7 +142,7 @@ function iniToObj(str) {
             resultPoint = result[matches[1]];
             continue;
         }
-        
+
         // standard line like "foo.bar2 = 2"
         if (matches = isData(line)) {
             var levels = matches[1].split('.');
@@ -170,19 +170,19 @@ function iniToObj(str) {
             // wyciąganie danych z danych
             var value = matches[3];
             if (value[0] == QUOTION_MARK) {
-                endIndex = 1;
+                endIndex = 0;
                 do {
                     endIndex = value.indexOf(QUOTION_MARK, endIndex + 1);
                 } while (
                     (value.substring(1, endIndex)).match(PATT_SLASH) &&
-                    (value.substring(1, endIndex)).match(PATT_SLASH)[1].length % 2 != 0 && 
+                    (value.substring(1, endIndex)).match(PATT_SLASH)[1].length % 2 != 0 &&
                     endIndex !== false
                 );
                 if (endIndex === false) {
                     throw new MultilevelIniException('Can\'t find end quote');
                     return;
                 }
-                
+
                 value = value.substring(1, endIndex);
             } else {
                 value = value.replace(/( *| *;.*)$/, '');
@@ -204,8 +204,8 @@ function iniToObj(str) {
 };
 
 /**
- * Read and convert to javascript object 
- * 
+ * Read and convert to javascript object
+ *
  * @param {string}   filePath
  * @param {function} callback
  */
@@ -227,7 +227,7 @@ function get(filePath, callback) {
 
 /**
  * Read and convert to javascript object
- * 
+ *
  * @param {string} filePath
  *
  * @return {object}
@@ -248,7 +248,7 @@ function getSync(filePath) {
  * @param {function} callback
  */
 function set(data, filePath, callback) {
-    fs.writeFile(filePath, objToIni(data, true), callback); 
+    fs.writeFile(filePath, objToIni(data, true), callback);
 };
 
 /**
@@ -258,7 +258,7 @@ function set(data, filePath, callback) {
  * @param {string} filePath
  */
 function setSync(data, filePath) {
-    fs.writeFileSync(filePath, objToIni(data, true)); 
+    fs.writeFileSync(filePath, objToIni(data, true));
 };
 
 /**
@@ -276,7 +276,7 @@ function MultilevelIniException(msg, code) {
  * toString()
  */
 MultilevelIniException.prototype.toString = function() {
-    return this.code + ': ' + this.message; 
+    return this.code + ': ' + this.message;
 };
 
 


### PR DESCRIPTION
An empty but quoted string wasn't parsed successfully (a double quote was returned).
Setting the index to 0 on [line 173](https://github.com/smhg/node-multilevel-ini/blob/cda19b2d7e869bd81cb975f52f1d0b9d38c36724/lib/multilevel-ini.js#L173) in `lib/multilevel-ini.js` fixes this.

I've also added a test case for this.
My editor cleaned up trailing spaces. Let me know if you don't want this.
